### PR TITLE
Protect job routes & hide jobs for non-admins

### DIFF
--- a/Frontend/src/main.jsx
+++ b/Frontend/src/main.jsx
@@ -19,6 +19,7 @@ import StudentDetail from "./pages/StudentDetail";
 import Metrics from "./pages/Metrics";
 import UploadCsv from "./pages/UploadCsv";
 import AdminPanel from "./pages/AdminPanel";
+import Jobs from "./pages/Jobs";
 
 // Simple guard component
 function RequireAuth({ children }) {
@@ -108,6 +109,15 @@ function AppRoutes() {
         element={
           <RequireAuth>
             <AdminPanel />
+          </RequireAuth>
+        }
+      />
+
+      <Route
+        path="/jobs"
+        element={
+          <RequireAuth>
+            <Jobs />
           </RequireAuth>
         }
       />

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -1,9 +1,28 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 export default function Dashboard() {
   const navigate = useNavigate();
   const schoolName = "Unitek Career Services";
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    async function checkRole() {
+      const token = localStorage.getItem("token");
+      if (!token) return;
+      try {
+        const res = await fetch("http://localhost:8001/users/me", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        setIsAdmin(data.role === "admin");
+      } catch {
+        // ignore
+      }
+    }
+    checkRole();
+  }, []);
 
   const handleLogout = () => {
     localStorage.removeItem("token");
@@ -37,6 +56,11 @@ export default function Dashboard() {
         <Link to="/upload-csv" className={cardClasses}>
           Upload CSV
         </Link>
+        {isAdmin && (
+          <Link to="/jobs" className={cardClasses}>
+            Manage Jobs
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/Frontend/src/pages/Jobs.jsx
+++ b/Frontend/src/pages/Jobs.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function Jobs() {
+  const [jobs, setJobs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+  const token = localStorage.getItem("token");
+
+  useEffect(() => {
+    async function load() {
+      if (!token) {
+        navigate("/", { replace: true });
+        return;
+      }
+      try {
+        const meRes = await fetch("http://localhost:8001/users/me", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!meRes.ok) {
+          navigate("/", { replace: true });
+          return;
+        }
+        const me = await meRes.json();
+        if (me.role !== "admin") {
+          navigate("/dashboard", { replace: true });
+          return;
+        }
+        const res = await fetch("http://localhost:8001/jobs/", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.detail || "Failed to fetch jobs");
+        setJobs(data);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [navigate, token]);
+
+  if (loading) return <p>Loading…</p>;
+  if (error) return <p className="text-red-600">{error}</p>;
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <h2 className="text-2xl font-bold">Job Postings</h2>
+      {jobs.length === 0 ? (
+        <p>No jobs available.</p>
+      ) : (
+        <ul className="space-y-2">
+          {jobs.map((job) => (
+            <li key={job.id} className="border p-2 rounded bg-white">
+              <p className="font-semibold">{job.title}</p>
+              <p>{job.description}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/api/routes/jobs.py
+++ b/app/api/routes/jobs.py
@@ -5,7 +5,7 @@ from typing import List
 from app.db.session import SessionLocal
 from app.models.job import Job
 from app.schemas.job import JobCreate, JobOut
-from app.api.dependencies import get_current_user
+from app.api.dependencies import get_current_user, admin_required
 from app.models.user import User
 
 # Debug confirmation that this route file was loaded
@@ -22,11 +22,11 @@ def get_db():
         db.close()
 
 # Create a new job posting
-@router.post("/jobs/", response_model=JobOut)
+@router.post("/jobs/", response_model=JobOut, dependencies=[Depends(admin_required)])
 def create_job(
     job_data: JobCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
 ):
     new_job = Job(**job_data.dict())
     db.add(new_job)
@@ -36,6 +36,6 @@ def create_job(
     return new_job
 
 # Get a list of all job postings
-@router.get("/jobs/", response_model=List[JobOut])
+@router.get("/jobs/", response_model=List[JobOut], dependencies=[Depends(admin_required)])
 def list_jobs(db: Session = Depends(get_db)):
     return db.query(Job).order_by(Job.created_at.desc()).all()


### PR DESCRIPTION
## Summary
- restrict job endpoints to admins only
- add Jobs page in React and only display to admins
- show Manage Jobs link only for admin users
- register Jobs route in router

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script)*