### PR TITLE
Add Placement management routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,12 @@ npm run dev
 ```
 
 By default the frontend is served at `http://localhost:5173` and communicates with the FastAPI backend.
+
+## Placement API
+
+Two endpoints allow recording and updating interview or placement status:
+
+- `POST /placements/` – create a new placement entry.
+- `PATCH /placements/{id}` – update an existing placement.
+
+Both endpoints require authentication just like the other protected routes.

--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,4 +1,4 @@
-from . import auth, students, jobs, match, reporting, bulk_upload_csv, admin_users, users
+from . import auth, students, jobs, match, reporting, bulk_upload_csv, admin_users, users, placements
 
 __all__ = [
     "auth",
@@ -9,4 +9,5 @@ __all__ = [
     "bulk_upload_csv",
     "admin_users",
     "users",
+    "placements",
 ]

--- a/app/api/routes/placements.py
+++ b/app/api/routes/placements.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.models.placement import Placement
+from app.schemas.placement import PlacementCreate, PlacementOut, PlacementUpdate
+from app.api.dependencies import get_current_user
+from app.models.user import User
+
+router = APIRouter(prefix="/placements", tags=["placements"])
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=PlacementOut)
+def create_placement(
+    placement: PlacementCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    new_placement = Placement(**placement.dict())
+    db.add(new_placement)
+    db.commit()
+    db.refresh(new_placement)
+    return new_placement
+
+
+@router.patch("/{placement_id}", response_model=PlacementOut)
+def update_placement(
+    placement_id: int,
+    placement_update: PlacementUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    placement = db.query(Placement).filter(Placement.id == placement_id).first()
+    if not placement:
+        raise HTTPException(status_code=404, detail="Placement not found")
+
+    update_data = placement_update.dict(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(placement, field, value)
+
+    db.commit()
+    db.refresh(placement)
+    return placement

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.api.routes import (
     bulk_upload_csv,
     admin_users,
     users,
+    placements,
 )
 
 # Instantiate FastAPI without automatic docs URLs
@@ -57,3 +58,4 @@ app.include_router(reporting.router, prefix="", tags=["Reporting"])
 app.include_router(bulk_upload_csv.router, prefix="", tags=["Bulk Upload"])
 app.include_router(admin_users.router, prefix="", tags=["Admin"])
 app.include_router(users.router, prefix="", tags=["Users"])
+app.include_router(placements.router, prefix="", tags=["Placements"])

--- a/app/schemas/placement.py
+++ b/app/schemas/placement.py
@@ -14,3 +14,8 @@ class PlacementOut(PlacementCreate):
 
     class Config:
         from_attributes = True
+
+class PlacementUpdate(BaseModel):
+    employer: Optional[str] = None
+    job_title: Optional[str] = None
+    status: Optional[str] = None


### PR DESCRIPTION
## Summary
- add `PlacementUpdate` schema
- create `/placements` API with POST and PATCH
- register new router in FastAPI app
- document placement endpoints in README

## Testing
- `pytest -q`