### PR TITLE
Add dark theme background and colors

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Global background styling */
+body {
+  @apply bg-primaryDark;
+  background-image:
+    repeating-linear-gradient(0deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 40px),
+    repeating-linear-gradient(90deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 40px);
+  background-size: 40px 40px;
+}

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -33,7 +33,7 @@ export default function Dashboard() {
     "flex-1 bg-white rounded-lg shadow p-6 text-center font-medium hover:shadow-lg transition";
 
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <div className="min-h-screen bg-transparent p-8">
       <div className="flex justify-between items-center max-w-4xl mx-auto mb-8">
         <h1 className="text-4xl font-bold">{schoolName}</h1>
         <button

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -44,7 +44,7 @@ export default function Login() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+    <div className="flex items-center justify-center min-h-screen bg-transparent">
       <form
         onSubmit={handleSubmit}
         className="bg-white p-8 rounded-lg shadow-md w-full max-w-sm space-y-6"

--- a/Frontend/src/pages/Register.jsx
+++ b/Frontend/src/pages/Register.jsx
@@ -38,7 +38,7 @@ export default function Register() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+    <div className="flex items-center justify-center min-h-screen bg-transparent">
       <form onSubmit={handleSubmit} className="bg-white p-8 rounded-lg shadow-md w-full max-w-sm space-y-6">
         <h2 className="text-2xl font-bold text-center text-blue-700">Register</h2>
         {error && <p className="text-red-600 text-sm text-center">{error}</p>}

--- a/Frontend/src/pages/StartProfile.jsx
+++ b/Frontend/src/pages/StartProfile.jsx
@@ -3,7 +3,7 @@ import StudentForm from "./StudentForm";
 
 export default function StartProfile() {
   return (
-    <div className="min-h-screen bg-gray-50 p-8">
+    <div className="min-h-screen bg-transparent p-8">
       <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow">
         <h2 className="text-2xl font-bold mb-4">Start Student Profile</h2>
         <StudentForm />

--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -1,6 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./index.html','./src/**/*.{js,jsx,ts,tsx}'],
-  theme: { extend: {} },
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primaryDark: '#112240',
+        circuitBlue: '#073642',
+      },
+    },
+  },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- extend Tailwind config with `primaryDark` and `circuitBlue`
- apply global background styles with grid lines
- switch several pages to use transparent background

## Testing
- `npm run dev` *(fails: vite not found)*