### PR TITLE
Add admin job management pages

### DIFF
--- a/Frontend/src/main.jsx
+++ b/Frontend/src/main.jsx
@@ -20,6 +20,8 @@ import Metrics from "./pages/Metrics";
 import UploadCsv from "./pages/UploadCsv";
 import AdminPanel from "./pages/AdminPanel";
 import Jobs from "./pages/Jobs";
+import CreateJob from "./pages/CreateJob";
+import JobMatches from "./pages/JobMatches";
 
 // Simple guard component
 function RequireAuth({ children }) {
@@ -118,6 +120,24 @@ function AppRoutes() {
         element={
           <RequireAuth>
             <Jobs />
+          </RequireAuth>
+        }
+      />
+
+      <Route
+        path="/jobs/create"
+        element={
+          <RequireAuth>
+            <CreateJob />
+          </RequireAuth>
+        }
+      />
+
+      <Route
+        path="/jobs/:id/matches"
+        element={
+          <RequireAuth>
+            <JobMatches />
           </RequireAuth>
         }
       />

--- a/Frontend/src/pages/CreateJob.jsx
+++ b/Frontend/src/pages/CreateJob.jsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function CreateJob() {
+  const navigate = useNavigate();
+  const token = localStorage.getItem("token");
+
+  const [formData, setFormData] = useState({
+    title: "",
+    license_type: "",
+    location: "",
+    schedule: "",
+    pay: "",
+    description: "",
+    tags: "",
+    urgency: "",
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function verifyAdmin() {
+      if (!token) {
+        navigate("/", { replace: true });
+        return;
+      }
+      const res = await fetch("http://localhost:8001/users/me", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        navigate("/", { replace: true });
+        return;
+      }
+      const me = await res.json();
+      if (me.role !== "admin") navigate("/dashboard", { replace: true });
+    }
+    verifyAdmin();
+  }, [navigate, token]);
+
+  function handleChange(e) {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      const payload = { ...formData };
+      if (payload.pay === "") delete payload.pay;
+      const res = await fetch("http://localhost:8001/jobs/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.detail || "Failed to create job");
+      navigate("/jobs", { replace: true });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h2 className="text-2xl font-bold mb-4">Create Job</h2>
+      {error && <p className="text-red-600 mb-2">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-3 bg-white p-4 rounded shadow">
+        <input
+          type="text"
+          name="title"
+          placeholder="Title"
+          value={formData.title}
+          onChange={handleChange}
+          required
+          className="border border-gray-300 rounded px-3 py-2 w-full"
+        />
+        <input
+          type="text"
+          name="license_type"
+          placeholder="License Type"
+          value={formData.license_type}
+          onChange={handleChange}
+          required
+          className="border border-gray-300 rounded px-3 py-2 w-full"
+        />
+        <input
+          type="text"
+          name="location"
+          placeholder="Location"
+          value={formData.location}
+          onChange={handleChange}
+          required
+          className="border border-gray-300 rounded px-3 py-2 w-full"
+        />
+        <input
+          type="text"
+          name="schedule"
+          placeholder="Schedule"
+          value={formData.schedule}
+          onChange={handleChange}
+          className="border border-gray-300 rounded px-3 py-2 w-full"
+        />
+        <input
+          type="number"
+          name="pay"
+          placeholder="Pay"
+          value={formData.pay}
+          onChange={handleChange}
+          step="0.01"
+          className="border border-gray-300 rounded px-3 py-2 w-full"
+        />
+        <textarea
+          name="description"
+          placeholder="Description"
+          value={formData.description}
+          onChange={handleChange}
+          className="border border-gray-300 rounded px-3 py-2 w-full"
+        />
+        <input
+          type="text"
+          name="tags"
+          placeholder="Tags"
+          value={formData.tags}
+          onChange={handleChange}
+          className="border border-gray-300 rounded px-3 py-2 w-full"
+        />
+        <input
+          type="text"
+          name="urgency"
+          placeholder="Urgency"
+          value={formData.urgency}
+          onChange={handleChange}
+          className="border border-gray-300 rounded px-3 py-2 w-full"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className={`w-full py-2 text-white rounded ${
+            loading ? "bg-blue-300" : "bg-blue-600 hover:bg-blue-700"
+          }`}
+        >
+          {loading ? "Submitting…" : "Create Job"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/Frontend/src/pages/JobMatches.jsx
+++ b/Frontend/src/pages/JobMatches.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate, useParams, Link } from "react-router-dom";
+
+export default function JobMatches() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const token = localStorage.getItem("token");
+
+  const [matches, setMatches] = useState([]);
+  const [job, setJob] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function load() {
+      if (!token) {
+        navigate("/", { replace: true });
+        return;
+      }
+      try {
+        const meRes = await fetch("http://localhost:8001/users/me", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!meRes.ok) {
+          navigate("/", { replace: true });
+          return;
+        }
+        const me = await meRes.json();
+        if (me.role !== "admin") {
+          navigate("/dashboard", { replace: true });
+          return;
+        }
+
+        const jobsRes = await fetch("http://localhost:8001/jobs/", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const jobsData = await jobsRes.json();
+        if (!jobsRes.ok) throw new Error(jobsData.detail || "Failed to fetch job");
+        setJob(jobsData.find((j) => j.id === parseInt(id)) || null);
+
+        const matchRes = await fetch(`http://localhost:8001/match-now/?job_id=${id}`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const matchData = await matchRes.json();
+        if (!matchRes.ok) throw new Error(matchData.detail || "Failed to fetch matches");
+        setMatches(matchData);
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id, navigate, token]);
+
+  if (loading) return <p>Loading…</p>;
+  if (error) return <p className="text-red-600">{error}</p>;
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <Link to="/jobs" className="text-blue-600 hover:underline">&larr; Back</Link>
+      <h2 className="text-2xl font-bold">
+        Matches for {job ? job.title : `Job ${id}`}
+      </h2>
+      {matches.length === 0 ? (
+        <p>No matches found.</p>
+      ) : (
+        <ul className="space-y-2">
+          {matches.map((m) => (
+            <li key={m.student.id} className="border p-2 rounded bg-white">
+              <p className="font-semibold">
+                {m.student.first_name} {m.student.last_name} – Score {m.match_score}
+              </p>
+              <p>{m.student.school}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/Frontend/src/pages/Jobs.jsx
+++ b/Frontend/src/pages/Jobs.jsx
@@ -47,15 +47,33 @@ export default function Jobs() {
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      <h2 className="text-2xl font-bold">Job Postings</h2>
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">Job Postings</h2>
+        <button
+          onClick={() => navigate("/jobs/create")}
+          className="px-3 py-1 bg-green-600 text-white rounded"
+        >
+          New Job
+        </button>
+      </div>
       {jobs.length === 0 ? (
         <p>No jobs available.</p>
       ) : (
         <ul className="space-y-2">
           {jobs.map((job) => (
             <li key={job.id} className="border p-2 rounded bg-white">
-              <p className="font-semibold">{job.title}</p>
-              <p>{job.description}</p>
+              <div className="flex justify-between">
+                <div>
+                  <p className="font-semibold">{job.title}</p>
+                  <p>{job.description}</p>
+                </div>
+                <button
+                  onClick={() => navigate(`/jobs/${job.id}/matches`)}
+                  className="px-2 py-1 bg-blue-600 text-white rounded self-start"
+                >
+                  Match Now
+                </button>
+              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- build a CreateJob page with form to POST `/jobs/`
- build JobMatches page that invokes `/match-now/` and shows ranked students
- extend Jobs page with create and match links
- wire new routes in `main.jsx`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*