### PR TITLE
Add primaryDark color in Tailwind theme

### DIFF
--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -3,6 +3,10 @@ module.exports = {
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}"
   ],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: { primaryDark: '#0f172a' },
+    },
+  },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- extend Tailwind theme configuration with a custom `primaryDark` color

## Testing
- `npm run lint` *(fails: ESLint configuration file missing)*
- `pytest`