### PR TITLE
Add Vite and Tailwind PostCSS configs

### DIFF
--- a/Frontend/postcss.config.js
+++ b/Frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});


### PR DESCRIPTION
## Summary
- add `postcss.config.js` configuring Tailwind and autoprefixer
- create `vite.config.js` using `@vitejs/plugin-react` and `@tailwindcss/vite`

## Testing
- `npm run build` *(fails: vite not found)*