### PR TITLE
Configure API base URL in frontend

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8001

--- a/Frontend/src/api.js
+++ b/Frontend/src/api.js
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8001";

--- a/Frontend/src/pages/StudentDetail.jsx
+++ b/Frontend/src/pages/StudentDetail.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { API_URL } from "../api";
 
 export default function StudentDetail() {
   const { id } = useParams();
@@ -10,7 +11,7 @@ export default function StudentDetail() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(`/students/${id}`);
+        const res = await fetch(`${API_URL}/students/${id}`);
         const data = await res.json();
         if (!res.ok) throw new Error(data.detail || "Failed to fetch student");
         setStudent(data);

--- a/Frontend/src/pages/StudentForm.jsx
+++ b/Frontend/src/pages/StudentForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { API_URL } from "../api";
 
 export default function StudentForm() {
   const [formData, setFormData] = useState({
@@ -41,7 +42,7 @@ export default function StudentForm() {
     });
 
     try {
-      const res = await fetch("/students/start", {
+      const res = await fetch(`${API_URL}/students/start`, {
         method: "POST",
         body: form,
       });

--- a/Frontend/src/pages/SubmittedProfiles.jsx
+++ b/Frontend/src/pages/SubmittedProfiles.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { API_URL } from "../api";
 
 export default function SubmittedProfiles() {
   const [students, setStudents] = useState([]);
@@ -9,7 +10,7 @@ export default function SubmittedProfiles() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch("/students/");
+        const res = await fetch(`${API_URL}/students/`);
         const data = await res.json();
         if (!res.ok) throw new Error(data.detail || "Failed to fetch students");
         setStudents(data);

--- a/Frontend/src/pages/UploadCSV.jsx
+++ b/Frontend/src/pages/UploadCSV.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { API_URL } from "../api";
 
 export default function UploadCsv() {
   const [file, setFile] = useState(null);
@@ -13,7 +14,7 @@ export default function UploadCsv() {
     form.append("file", file);
 
     try {
-      const res = await fetch("/students/upload-csv", {
+      const res = await fetch(`${API_URL}/students/upload-csv`, {
         method: "POST",
         body: form,
       });

--- a/README.md
+++ b/README.md
@@ -23,13 +23,18 @@ Copy `.env.example` to `.env` and modify the values as needed:
 
 ```bash
 cp .env.example .env
+cd Frontend
+cp .env.example .env
+cd ..
 ```
+The commands inside `Frontend/` create a `.env` file so the React app can read `VITE_API_URL`.
 
 The main variables are:
 
 - `DATABASE_URL` – database connection string (defaults to the bundled SQLite database)
 - `SECRET_KEY` – key used to sign JWT tokens
 - `OPENAI_API_KEY` – your API key for OpenAI services
+- `VITE_API_URL` – base URL for the frontend to reach the API (defaults to `http://localhost:8001`)
 
 ## Running the Backend
 


### PR DESCRIPTION
## Summary
- add a reusable API_URL constant
- switch student-related API calls to use API_URL
- document VITE_API_URL in README
- provide example env file for the React app

## Testing
- `pytest -q`