### PR TITLE
Align port usage

### DIFF
--- a/Frontend/src/pages/AdminPanel.jsx
+++ b/Frontend/src/pages/AdminPanel.jsx
@@ -16,7 +16,7 @@ export default function AdminPanel() {
       }
       try {
         // Verify role
-        const meRes = await fetch("http://localhost:8001/users/me", {
+        const meRes = await fetch("http://localhost:8000/users/me", {
           headers: { Authorization: `Bearer ${token}` },
         });
         if (!meRes.ok) {
@@ -28,7 +28,7 @@ export default function AdminPanel() {
           navigate("/dashboard", { replace: true });
           return;
         }
-        const res = await fetch("http://localhost:8001/admin/pending-users", {
+        const res = await fetch("http://localhost:8000/admin/pending-users", {
           headers: { Authorization: `Bearer ${token}` },
         });
         if (!res.ok) throw new Error("Failed to fetch pending users");
@@ -45,7 +45,7 @@ export default function AdminPanel() {
 
   async function handleAction(id, action) {
     try {
-      const res = await fetch(`http://localhost:8001/admin/${action}-user/${id}`, {
+      const res = await fetch(`http://localhost:8000/admin/${action}-user/${id}`, {
         method: "POST",
         headers: { Authorization: `Bearer ${token}` },
       });

--- a/Frontend/src/pages/CreateJob.jsx
+++ b/Frontend/src/pages/CreateJob.jsx
@@ -24,7 +24,7 @@ export default function CreateJob() {
         navigate("/", { replace: true });
         return;
       }
-      const res = await fetch("http://localhost:8001/users/me", {
+      const res = await fetch("http://localhost:8000/users/me", {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (!res.ok) {
@@ -49,7 +49,7 @@ export default function CreateJob() {
     try {
       const payload = { ...formData };
       if (payload.pay === "") delete payload.pay;
-      const res = await fetch("http://localhost:8001/jobs/", {
+      const res = await fetch("http://localhost:8000/jobs/", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/Frontend/src/pages/Dashboard.jsx
+++ b/Frontend/src/pages/Dashboard.jsx
@@ -11,7 +11,7 @@ export default function Dashboard() {
       const token = localStorage.getItem("token");
       if (!token) return;
       try {
-        const res = await fetch("http://localhost:8001/users/me", {
+        const res = await fetch("http://localhost:8000/users/me", {
           headers: { Authorization: `Bearer ${token}` },
         });
         if (!res.ok) return;

--- a/Frontend/src/pages/JobMatches.jsx
+++ b/Frontend/src/pages/JobMatches.jsx
@@ -18,7 +18,7 @@ export default function JobMatches() {
         return;
       }
       try {
-        const meRes = await fetch("http://localhost:8001/users/me", {
+        const meRes = await fetch("http://localhost:8000/users/me", {
           headers: { Authorization: `Bearer ${token}` },
         });
         if (!meRes.ok) {
@@ -31,14 +31,14 @@ export default function JobMatches() {
           return;
         }
 
-        const jobsRes = await fetch("http://localhost:8001/jobs/", {
+        const jobsRes = await fetch("http://localhost:8000/jobs/", {
           headers: { Authorization: `Bearer ${token}` },
         });
         const jobsData = await jobsRes.json();
         if (!jobsRes.ok) throw new Error(jobsData.detail || "Failed to fetch job");
         setJob(jobsData.find((j) => j.id === parseInt(id)) || null);
 
-        const matchRes = await fetch(`http://localhost:8001/match-now/?job_id=${id}`, {
+        const matchRes = await fetch(`http://localhost:8000/match-now/?job_id=${id}`, {
           method: "POST",
           headers: { Authorization: `Bearer ${token}` },
         });

--- a/Frontend/src/pages/Jobs.jsx
+++ b/Frontend/src/pages/Jobs.jsx
@@ -15,7 +15,7 @@ export default function Jobs() {
         return;
       }
       try {
-        const meRes = await fetch("http://localhost:8001/users/me", {
+        const meRes = await fetch("http://localhost:8000/users/me", {
           headers: { Authorization: `Bearer ${token}` },
         });
         if (!meRes.ok) {
@@ -27,7 +27,7 @@ export default function Jobs() {
           navigate("/dashboard", { replace: true });
           return;
         }
-        const res = await fetch("http://localhost:8001/jobs/", {
+        const res = await fetch("http://localhost:8000/jobs/", {
           headers: { Authorization: `Bearer ${token}` },
         });
         const data = await res.json();

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -20,7 +20,7 @@ export default function Login() {
     setLoading(true);
 
     try {
-      const res = await fetch("http://localhost:8001/login", {
+      const res = await fetch("http://localhost:8000/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData),

--- a/Frontend/src/pages/Register.jsx
+++ b/Frontend/src/pages/Register.jsx
@@ -18,7 +18,7 @@ export default function Register() {
     setLoading(true);
 
     try {
-      const res = await fetch("http://localhost:8001/register", {
+      const res = await fetch("http://localhost:8000/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(formData)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The main variables are:
 After activating the virtual environment and preparing environment variables, start the FastAPI application with:
 
 ```bash
-uvicorn app.main:app --reload
+uvicorn app.main:app --reload --port 8000
 ```
 
 The API will be available at `http://localhost:8000` and documentation can be accessed at `/docs` when running in development mode.
@@ -51,7 +51,7 @@ npm install
 npm run dev
 ```
 
-By default the frontend is served at `http://localhost:5173` and communicates with the FastAPI backend.
+By default the frontend is served at `http://localhost:5173` and communicates with the FastAPI backend on port **8000**.
 
 ## Placement API
 

--- a/website test
+++ b/website test
@@ -1,1 +1,1 @@
-uvicorn app.main:app --reload --port 8001
+uvicorn app.main:app --reload --port 8000


### PR DESCRIPTION
## Summary
- run backend at `:8000`
- reference the same port in docs and scripts
- update all frontend API calls

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `python -m compileall -q`