### PR TITLE
Fix Tailwind config for ESM

### DIFF
--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   content: [
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}"
@@ -9,4 +9,4 @@ module.exports = {
     },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- convert `tailwind.config.js` to ESM so Vite can load it

## Testing
- `npx --version` *(fails: no `npx` in PATH)*