### PR TITLE
Fix Tailwind bg-primaryDark error

### DIFF
--- a/Frontend/tailwind.config.cjs
+++ b/Frontend/tailwind.config.cjs
@@ -9,4 +9,4 @@ module.exports = {
     },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- rename `tailwind.config.js` -> `tailwind.config.cjs`
- export with `module.exports` so Tailwind config is loaded correctly

## Testing
- `node --version`