### PR TITLE
Add first and last name to user registration

### DIFF
--- a/Frontend/src/pages/Register.jsx
+++ b/Frontend/src/pages/Register.jsx
@@ -1,7 +1,13 @@
 import React, { useState } from "react";
 
 export default function Register() {
-  const [formData, setFormData] = useState({ email: "", password: "", school: "" });
+  const [formData, setFormData] = useState({
+    email: "",
+    password: "",
+    first_name: "",
+    last_name: "",
+    school: ""
+  });
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
   const [isLoading, setLoading] = useState(false);
@@ -29,7 +35,7 @@ export default function Register() {
       }
       setMessage(data.message || "Account request submitted. Awaiting approval.");
       // optionally clear form
-      setFormData({ email: "", password: "", school: "" });
+      setFormData({ email: "", password: "", first_name: "", last_name: "", school: "" });
     } catch (err) {
       setError(err.message);
     } finally {
@@ -66,6 +72,32 @@ export default function Register() {
             autoComplete="new-password"
             placeholder="Password"
             value={formData.password}
+            onChange={handleChange}
+            required
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="first_name" className="sr-only">First Name</label>
+          <input
+            id="first_name"
+            name="first_name"
+            type="text"
+            placeholder="First Name"
+            value={formData.first_name}
+            onChange={handleChange}
+            required
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="last_name" className="sr-only">Last Name</label>
+          <input
+            id="last_name"
+            name="last_name"
+            type="text"
+            placeholder="Last Name"
+            value={formData.last_name}
             onChange={handleChange}
             required
             className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -35,10 +35,12 @@ def register(user_data: UserRegister, db: Session = Depends(get_db)):
 
     new_user = User(
         email=user_data.email,
+        first_name=user_data.first_name,
+        last_name=user_data.last_name,
         hashed_password=get_password_hash(user_data.password),
         role="staff",
         status="pending",
-        school = user_data.school
+        school=user_data.school
     )
     db.add(new_user)
     db.commit()

--- a/app/api/routes/users.py
+++ b/app/api/routes/users.py
@@ -39,6 +39,10 @@ def update_user(
         user.email = user_update.email
     if user_update.school is not None:
         user.school = user_update.school
+    if user_update.first_name is not None:
+        user.first_name = user_update.first_name
+    if user_update.last_name is not None:
+        user.last_name = user_update.last_name
     db.commit()
     db.refresh(user)
     return user

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -5,6 +5,8 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
+    first_name = Column(String, nullable=False)
+    last_name = Column(String, nullable=False)
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     role = Column(String, default="staff")

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -7,6 +7,8 @@ class UserCreate(BaseModel):
 class UserOut(BaseModel):
     id: int
     email: EmailStr
+    first_name: str
+    last_name: str
     role: str
     status: str
     school: str
@@ -17,6 +19,8 @@ class UserOut(BaseModel):
 class UserRegister(BaseModel):
     email: EmailStr
     password: str
+    first_name: str
+    last_name: str
     school: str
 
 from typing import Optional
@@ -24,6 +28,8 @@ from typing import Optional
 class UserUpdate(BaseModel):
     email: Optional[EmailStr] = None
     school: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
 
 class PasswordChange(BaseModel):
     old_password: str

--- a/scripts/create_test_user.py
+++ b/scripts/create_test_user.py
@@ -16,9 +16,12 @@ def create_user():
 
     # Create user
     new_user = User(
+        first_name="Test",
+        last_name="User",
         email=test_email,
         hashed_password=get_password_hash(test_password),
-        role="staff"
+        role="staff",
+        school="Test School"
     )
     db.add(new_user)
     db.commit()


### PR DESCRIPTION
## Summary
- extend `User` model with first and last name
- capture names in the user schemas
- update register endpoint to save names
- allow updating names via `/users/{id}`
- update React register page for new inputs
- include sample names in `create_test_user.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_683a0bc37c408333811036aa6825adda