### PR TITLE
Add auth headers and redirect on unauthorized

### DIFF
--- a/Frontend/src/pages/EditStudent.jsx
+++ b/Frontend/src/pages/EditStudent.jsx
@@ -27,6 +27,10 @@ export default function EditStudent() {
         const res = await fetch(`/students/${id}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
+        if (res.status === 401 || res.status === 403) {
+          navigate("/", { replace: true });
+          return;
+        }
         const data = await res.json();
         if (!res.ok) throw new Error(data.detail || "Failed to load student");
         setFormData((prev) => ({ ...prev, ...data }));
@@ -69,6 +73,10 @@ export default function EditStudent() {
         headers: { Authorization: `Bearer ${token}` },
         body: form,
       });
+      if (res.status === 401 || res.status === 403) {
+        navigate("/", { replace: true });
+        return;
+      }
       const data = await res.json();
       if (!res.ok) throw new Error(data.detail || "Update failed");
       setMessage("Student updated.");

--- a/Frontend/src/pages/Metrics.jsx
+++ b/Frontend/src/pages/Metrics.jsx
@@ -1,17 +1,25 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 export default function Metrics() {
   const schoolName = "Unitek Career Services";
   const [metrics, setMetrics] = useState(null);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  const token = localStorage.getItem("token");
 
   useEffect(() => {
     async function loadMetrics() {
       try {
         const res = await fetch(
-          `/reporting/overview?school=${encodeURIComponent(schoolName)}`
+          `/reporting/overview?school=${encodeURIComponent(schoolName)}`,
+          { headers: { Authorization: `Bearer ${token}` } }
         );
+        if (res.status === 401 || res.status === 403) {
+          navigate("/", { replace: true });
+          return;
+        }
         const data = await res.json();
         if (!res.ok) {
           throw new Error(data.detail || "Failed to fetch metrics");

--- a/Frontend/src/pages/StudentDetail.jsx
+++ b/Frontend/src/pages/StudentDetail.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { API_URL } from "../api";
 
 export default function StudentDetail() {
   const { id } = useParams();
+  const navigate = useNavigate();
+  const token = localStorage.getItem("token");
   const [student, setStudent] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -11,7 +13,13 @@ export default function StudentDetail() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(`${API_URL}/students/${id}`);
+        const res = await fetch(`${API_URL}/students/${id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.status === 401 || res.status === 403) {
+          navigate("/", { replace: true });
+          return;
+        }
         const data = await res.json();
         if (!res.ok) throw new Error(data.detail || "Failed to fetch student");
         setStudent(data);

--- a/Frontend/src/pages/StudentForm.jsx
+++ b/Frontend/src/pages/StudentForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { API_URL } from "../api";
 
 export default function StudentForm() {
@@ -16,6 +17,8 @@ export default function StudentForm() {
   });
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+  const token = localStorage.getItem("token");
 
   function handleChange(e) {
     const { name, value } = e.target;
@@ -44,8 +47,13 @@ export default function StudentForm() {
     try {
       const res = await fetch(`${API_URL}/students/start`, {
         method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
         body: form,
       });
+      if (res.status === 401 || res.status === 403) {
+        navigate("/", { replace: true });
+        return;
+      }
       const data = await res.json();
       if (!res.ok) throw new Error(data.detail || "Submission failed");
       setMessage("Profile submitted successfully.");

--- a/Frontend/src/pages/SubmittedProfiles.jsx
+++ b/Frontend/src/pages/SubmittedProfiles.jsx
@@ -1,16 +1,24 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { API_URL } from "../api";
 
 export default function SubmittedProfiles() {
   const [students, setStudents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const navigate = useNavigate();
+  const token = localStorage.getItem("token");
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(`${API_URL}/students/`);
+        const res = await fetch(`${API_URL}/students/`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.status === 401 || res.status === 403) {
+          navigate("/", { replace: true });
+          return;
+        }
         const data = await res.json();
         if (!res.ok) throw new Error(data.detail || "Failed to fetch students");
         setStudents(data);

--- a/Frontend/src/pages/UploadCSV.jsx
+++ b/Frontend/src/pages/UploadCSV.jsx
@@ -1,10 +1,13 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { API_URL } from "../api";
 
 export default function UploadCsv() {
   const [file, setFile] = useState(null);
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+  const token = localStorage.getItem("token");
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -16,8 +19,13 @@ export default function UploadCsv() {
     try {
       const res = await fetch(`${API_URL}/students/upload-csv`, {
         method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
         body: form,
       });
+      if (res.status === 401 || res.status === 403) {
+        navigate("/", { replace: true });
+        return;
+      }
       const data = await res.json();
       if (!res.ok) throw new Error(data.detail || "Upload failed");
       setMessage(`Created ${data.total} profiles.`);


### PR DESCRIPTION
## Summary
- protect fetch calls on several pages
- add `Authorization` header from localStorage
- redirect to login page for 401/403 responses

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683a3390fee0833395b3501b666446a9